### PR TITLE
Fix typo in Auth.vue

### DIFF
--- a/src/components/views/Auth.vue
+++ b/src/components/views/Auth.vue
@@ -10,5 +10,5 @@ export default {
 }
 </script>
 
-<style lang="scss" scped>
+<style lang="scss" scoped>
 </style>


### PR DESCRIPTION
Te comiste la letra `o` en `scoped`